### PR TITLE
Fix in `Makefile` and improving `README.md`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,55 @@
-TARGET = mrbtris.bin
+# mrbtris: Sample game for Sega Dreamcast written in Ruby
 
-OBJS = src/mrbtris.o src/main.o src/game.o romdisk.o
+PROJECT_NAME = mrbtris
 
-# order here is important!
-MRB_SOURCES=src/block_shapes.rb src/game.rb src/start_game.rb
+# Name of the compiled mruby script
+MRB_BYTECODE_IREP_NAME = game
 
-MRB_BYTECODE = src/game.c
+# Ruby sources
+# The order here is important!
+MRB_SOURCES = src/block_shapes.rb src/$(MRB_BYTECODE_IREP_NAME).rb src/start_$(MRB_BYTECODE_IREP_NAME).rb
 
+# mruby script output
+MRB_BYTECODE = src/$(MRB_BYTECODE_IREP_NAME).c
+
+# KallistiOS Romdisk directory
 KOS_ROMDISK_DIR = romdisk
 
+# Binary object sources
+OBJS = src/$(PROJECT_NAME).o src/main.o src/$(MRB_BYTECODE_IREP_NAME).o $(KOS_ROMDISK_DIR).o
+
+# Directory path where mruby is installed
 MRB_ROOT = /opt/mruby
 
+# Compiler flags
 CFLAGS = -I$(MRB_ROOT)/include/ -L$(MRB_ROOT)/build/dreamcast/lib/
 
-all: rm-elf $(TARGET)
+# Program files
+TARGETFILE = $(PROJECT_NAME).elf
+BINARYFILE = $(PROJECT_NAME).bin
+BOOTFILE = cd_root/1ST_READ.BIN
+
+all: rm-elf $(TARGETFILE)
 
 include $(KOS_BASE)/Makefile.rules
 
-clean:
-	-rm -f $(TARGET) $(OBJS) romdisk.* $(MRB_BYTECODE)
-
 rm-elf:
-	-rm -f $(TARGET) romdisk.*
+	-rm -f $(TARGETFILE) $(BINARYFILE) $(BOOTFILE)
 
-$(TARGET): mrbtris.elf
-	sh-elf-objcopy -R .stack -O binary mrbtris.elf mrbtris.bin
+rm-obj:
+	-rm -f $(OBJS) $(KOS_ROMDISK_DIR).img $(MRB_BYTECODE)
+	
+clean: rm-elf rm-obj
 
-mrbtris.elf: $(OBJS) $(MRB_BYTECODE)
-	kos-cc $(CFLAGS) -o $(TARGET) $(OBJS) -lmruby -lm
+$(TARGETFILE): $(OBJS) $(MRB_BYTECODE)
+	kos-cc $(CFLAGS) -o $(TARGETFILE) $(OBJS) -lmruby -lm
+	kos-objcopy -O binary $(TARGETFILE) $(BINARYFILE)
+	
+$(MRB_BYTECODE): $(MRB_SOURCES)
+	$(MRB_ROOT)/bin/mrbc -g -B$(MRB_BYTECODE_IREP_NAME) -o $(MRB_BYTECODE) $(MRB_SOURCES)
 
-$(MRB_BYTECODE): src/start_game.rb src/game.rb
-	$(MRB_ROOT)/bin/mrbc -g -Bgame -o src/game.c $(MRB_SOURCES)
+run: $(TARGETFILE)
+	$(KOS_LOADER) $(TARGETFILE)
 
-run: $(TARGET)
-	$(KOS_LOADER) $(TARGET)
-
-dist:
-	rm -f $(OBJS) romdisk.o romdisk.img
-	$(KOS_STRIP) $(TARGET)
+dist: $(TARGETFILE)
+	$(KOS_BASE)/utils/scramble/scramble $(BINARYFILE) $(BOOTFILE)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project aims to provide a simple example of how to use **KallistiOS** (KOS)
 
 ## Demonstration
 
-Below you may find a video of this game running on the real hardware.
+Below you may find a video of this game running on the real hardware (early version):
 [![#mrbtris running on Sega Dreamcast](https://i.imgur.com/sU9gnJR.png)](https://vimeo.com/335686570)
 
 ## TODO
@@ -28,7 +28,7 @@ Below you may find a video of this game running on the real hardware.
 
 If you have a working [KallistiOS](http://gamedev.allusion.net/softprj/kos/) environment, you will have to install the `rake` and `bison` packages (e.g. using `apt`, `brew` or `pacman`). If you are using [DreamSDK](https://dreamsdk.org), you will have to install the [RubyInstaller](https://rubyinstaller.org/) package separately, in that case, `rake` should be available in the `PATH` environment variable.
 
-Install  `mruby`:
+Install `mruby`:
 
 	cd /opt
 	git clone https://github.com/mruby/mruby.git
@@ -62,9 +62,7 @@ Unfortunately, running on the real hardware has been the only way for me to test
 
 If you want to try this software in your real Dreamcast and/or in an another emulator (like [Demul, Redream, Reicast](https://dreamcast.wiki/Dreamcast_emulators)...), you may create a **Padus DiscJuggler** (`cdi`) image. For example, if you are using [DreamSDK](https://dreamsdk.org), you may do the following:
 
-	make dist
-	elf2bin mrbtris.elf
-	scramble mrbtris.bin cd_root/1ST_READ.BIN
+	make dist	
 	makedisc mrbtris.cdi cd_root
 
 This will produces the `mrbtris.cdi` image file that you may burn onto a CD-R or use in a Dreamcast emulator. Alternatively, you may use [BootDreams](https://dcemulation.org/index.php?title=BootDreams) (on Windows) or similar tools. If you are on non-Windows systems, you may check the [img4dc source code](https://github.com/Kazade/img4dc).
@@ -72,4 +70,10 @@ This will produces the `mrbtris.cdi` image file that you may burn onto a CD-R or
 ### Using dcload/dc-tool (part of KallistiOS)
 
 If you have a [Coders Cable](https://dreamcast.wiki/Coder%27s_cable) or a [Broadband Adapter](https://dreamcast.wiki/Broadband_adapter) (BBA) / [LAN Adapter](https://dreamcast.wiki/LAN_adapter), you could also the `dcload` program (part of **KallistiOS**) to load it directly on the Sega Dreamcast. It should load as a normal Sega Dreamcast program.
+
+To do that, you may enter the following:
+
+	make run
+
+This will execute `dc-tool` using the `mrbtris.elf` binary file as target.
 


### PR DESCRIPTION
This PR will fix the latest `Makefile` to proper generate `mrbtris.elf` and `mrbtris.bin` files at the same time.
The `Makefile` has been cleaned up/reworked as well. The `README.md` file has been updated accordingly.